### PR TITLE
fixes and ensures mainly for install.py and photon.py

### DIFF
--- a/core/grammar/genGrammar.py
+++ b/core/grammar/genGrammar.py
@@ -7,7 +7,7 @@ try:
     grammar = sys.argv[1]
 except:
     print('Please, provide a grammar')
-    exit()
+    sys.exit()
 
 def genRules(val):
     vals = [ i for i in re.split('(\W)', val) if not (i=='' or i==' ' or i=='\n') ]

--- a/core/interpreter.py
+++ b/core/interpreter.py
@@ -68,7 +68,7 @@ class Interpreter():
             else:
                 if not self.transpileOnly:
                     self.engine.run()
-                    exit()
+                    sys.exit()
                 else:
                     self.engine.write()
                     self.classes = self.engine.classes

--- a/core/photon.py
+++ b/core/photon.py
@@ -4,7 +4,9 @@
 
 if __name__ == "__main__":
     import sys
-    sys.path.insert(0, @PHOTON_INSTALL_PATH)
+    import os
+    PHOTON_INSTALL_PATH = os.path.dirname(os.path.realpath(__file__))
+    sys.path.insert(0, PHOTON_INSTALL_PATH)
     from interpreter import Interpreter
     from builder import Builder
     try:
@@ -18,7 +20,7 @@ if __name__ == "__main__":
     if first == 'build':
         try:
             platform = sys.argv[2]
-            Builder(platform, standardLibs=@PHOTON_INSTALL_PATH+'Libs/')
+            Builder(platform, standardLibs=os.path.join(PHOTON_INSTALL_PATH, 'Libs/'))
         except IndexError:
             print('Welcome to Photon builder!')
             print('')
@@ -60,7 +62,6 @@ if __name__ == "__main__":
         print('    photon build [platform] Builds and runs the project for the target platform')
         print('    photon set lang=[lang] Set the default language to [lang]')
     elif first == 'android-view':
-        import os
         os.system('adb exec-out screenrecord --output-format=h264 - | ffplay -framerate 60 -probesize 32 -sync video  -')
     else:
         filename = first
@@ -73,4 +74,4 @@ if __name__ == "__main__":
             #print(f'Error: {e} loading default lang. Using c')
             #print(f'You can change that using "photon set defaultLang=lang"')
             lang = 'c'
-        Interpreter(filename, lang=lang, standardLibs=@PHOTON_INSTALL_PATH+'/Libs/').run()
+        Interpreter(filename, lang=lang, standardLibs=os.path.join(PHOTON_INSTALL_PATH, 'Libs/')).run()

--- a/core/photon.py
+++ b/core/photon.py
@@ -5,7 +5,7 @@
 if __name__ == "__main__":
     import sys
     import os
-    PHOTON_INSTALL_PATH = os.path.dirname(os.path.realpath(__file__))
+    PHOTON_INSTALL_PATH = getattr(sys, '_MEIPASS', os.path.dirname(os.path.realpath(__file__)))
     sys.path.insert(0, PHOTON_INSTALL_PATH)
     from interpreter import Interpreter
     from builder import Builder
@@ -16,7 +16,7 @@ if __name__ == "__main__":
         print('Or try:')
         print('    photon --help')
         print('To see more options')
-        exit()
+        sys.exit()
     if first == 'build':
         try:
             platform = sys.argv[2]

--- a/core/photon.py
+++ b/core/photon.py
@@ -35,7 +35,8 @@ if __name__ == "__main__":
             print('Please provide the package name. Ex:\n    photon logcat com.photon.example')
     elif first == 'set':
         command = ' '.join(sys.argv[2:])
-        import json, os, pathlib
+        import json
+        import pathlib
         home = pathlib.Path.home()
         if not '.photon' in os.listdir(home):
             os.mkdir(f'{home}/.photon')

--- a/core/photon.py
+++ b/core/photon.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     elif first == 'logcat':
         try:
             packageName = sys.argv[2]
-            s.call("adb shell 'logcat --pid=$(pidof -s {packageName})'", shell=True)
+            os.system(f"adb shell 'logcat --pid=$(pidof -s {packageName})'")
         except IndexError:
             print('Please provide the package name. Ex:\n    photon logcat com.photon.example')
     elif first == 'set':

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ with open('core/photon.py') as w:
 
 code = code.replace('PHOTON_INSTALL_PATH =', f'PHOTON_INSTALL_PATH = r"{os.getcwd()}/core" #')
 
-if sys.platform in {'linux','darwin'}:
+if sys.platform in {'linux', 'linux2', 'darwin'}:
     try:
         with open('/usr/local/bin/photon','w') as w:
             w.write(code)
@@ -22,7 +22,7 @@ if sys.platform in {'linux','darwin'}:
         print(
         " Please run this script with the 'sudo' command.\n",
         "Example:\n    'sudo python3 install.py'")
-elif sys.platform == 'win32':
+elif sys.platform in {'win32', 'cygwin', 'msys'}:
     p_dir = os.path.expandvars('%ProgramFiles%\\Photon')
     try:
         if not os.path.exists(p_dir):

--- a/install.py
+++ b/install.py
@@ -8,7 +8,7 @@ import sys
 with open('core/photon.py') as w:
     code = w.read()
 
-code = code.replace('@PHOTON_INSTALL_PATH', f'r"{os.getcwd()}/core"')
+code = code.replace('PHOTON_INSTALL_PATH =', f'PHOTON_INSTALL_PATH = r"{os.getcwd()}/core" #')
 
 if sys.platform in {'linux','darwin'}:
     try:


### PR DESCRIPTION
* make `photon.py` works without `install.py`, it is for the future when using PyInstaller
(and bcs that @ lets all my IDE red kk)
* fix a NameError
* ensure more possible `sys.platform` values representing Windows or Linux
* change interactive shell helper `exit()` with `sys.exit()`