### PR TITLE
simplify install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -6,76 +6,33 @@ import os
 import sys
 from core.dependencies import haveDependencies, resolveDependencies
 
+
+PHOTON_PATH = os.path.join(os.path.dirname(__file__), 'core', 'photon.py')
+
 try:
-    import ctypes
-    haveCtypes = True
-except ModuleNotFoundError:
-    # Probably on raspberrypy
-    haveCtypes = False
-
-# Obtains a simple description of the current operating system platform
-def getSystem():
     if sys.platform in {'linux', 'linux2', 'darwin'}:
-        return "unix"
-    elif os.name == "nt" or os.environ.get('OS', '') != 'Windows_NT' or sys.platform in {'win32', 'cygwin', 'msys'}:
-        return "win"
-    return None
-
-# Returns if the script is being run as an administrator (ROOT)
-def isAdmin():
-    try:
-        platform_os = getSystem()
-        if platform_os == "unix":
-            return os.getuid() == 0
-        elif platform_os == "win":
-            return ctypes.windll.shell32.IsUserAnAdmin()
-        return False
-    except:
-        return False
-
-platform_os = getSystem()
-
-if haveCtypes and not isAdmin() and platform_os == "win":
-    try:
-        ctypes.windll.shell32.ShellExecuteW(None, "runas", sys.executable, " ".join(sys.argv), None, 1)
-        sys.exit()
-    except:
-        pass
-
-with open(f'{os.path.dirname(__file__)}/core/photon.py') as w:
-    code = w.read()
-
-code = code.replace('PHOTON_INSTALL_PATH =', f'PHOTON_INSTALL_PATH = r"{os.path.dirname(__file__)}/core" #')
-
-if platform_os == "unix":
-    try:
-        with open('/usr/local/bin/photon', 'w') as w:
-            w.write(code)
+        os.symlink(PHOTON_PATH, '/usr/local/bin/photon')
         os.chmod('/usr/local/bin/photon', 0o777)
-        print("Successfully installed! Now you can use the photon command!")
-        input('Press enter to close and play with Photon!')
-    except PermissionError:
-        print(
-        " Please run this script with the 'sudo' command.\n",
-        "Example:\n    'sudo python3 install.py'")
-        input('Press enter to close.')
-elif platform_os == "win":
-    p_dir = os.path.expandvars('%ProgramFiles%\\Photon')
-    try:
+    elif sys.platform in {'win32', 'cygwin', 'msys'} or os.name == "nt" or os.environ.get('OS', '') == 'Windows_NT':
+        p_dir = os.path.expandvars('%ProgramFiles%\\Photon')
         if not os.path.exists(p_dir):
             os.mkdir(p_dir)
-        with open(os.path.join(p_dir, 'photon.py'), 'w') as w:
-            w.write(code)
         with open(os.path.join(p_dir, 'photon.bat'), 'w') as w:
-            w.write('@echo off\nset bat_dir=%~dp0\npython "%bat_dir%photon.py" "%1" "%2" "%3"')
+            w.write(f'@echo off\npython "{PHOTON_PATH}" "%*"')
         os.system(f'setx /M PATH "%PATH%;{p_dir}"')
-        print("Successfully installed! Now you can use the photon command!")
-    except PermissionError:
-        print('The installation has not been completed. Try to run the script as administrator')
-else:
-    print('Automatic installation in this system is not supported yet. Press enter to close.')
-    input()
-    sys.exit()
+    else:
+        print('Automatic installation in this system is not supported yet.')
+        input('Press enter to close')
+        sys.exit(1)
+except PermissionError:
+    print('The installation failed due to lack of permissions.',
+          'Run the proper script for your operational system or try to execute this as super user/administrator',
+          sep='\n')
+    input('Press enter to close')
+    sys.exit(1)
 
 if not haveDependencies('c', sys.platform):
     resolveDependencies('c', sys.platform)
+
+print("Successfully installed! Now you can use the photon command!")
+input('Press enter to close and play with Photon!')

--- a/install.py
+++ b/install.py
@@ -18,7 +18,7 @@ try:
         if not os.path.exists(p_dir):
             os.mkdir(p_dir)
         with open(os.path.join(p_dir, 'photon.bat'), 'w') as w:
-            w.write(f'@echo off\npython "{PHOTON_PATH}" "%*"')
+            w.write(f'@echo off\npython "{PHOTON_PATH}" %*')
         os.system(f'setx /M PATH "%PATH%;{p_dir}"')
     else:
         print('Automatic installation in this system is not supported yet.')


### PR DESCRIPTION
the points:

* as each platform will have an install script as `linuxinstaller.sh` and `windowsinstaller.bat` and they are supposed to elevate permissions before executing `install.py`, the file is kinda internal and whoever uses this should know how to `sudo` or right-click the cmd and select "Run as Administrator". Check the permissions in redundant and can be avoided with a message explaining why the installation failed.
* accordingly, `ctypes` module is not being used and there is no need to check if we are on a Raspberry Pi
* as the info about the platform is just used once, lets exclude the function for this simple task. `sys.platform in {'os1', 'os2', 'os3'}` is clearer enough
* install on both systems depends on where the user downloaded/cloned the repo. Copy and modify `photon.py` to another location is not intuitive, besides make harder to develop as there are 2 files on different places. On linux a symlink can be used. On windows the .bat pointing to the installation path.

also:
* `os.path.join` is safer for using across platforms
* check `sys.platfom in {'win32', 'cygwin', 'msys'}` before other methods is faster
* `os.environ.get('OS', '') != 'Windows_NT'` says we are NOT on windows, should be `==` instead
* `%*` takes all arguments for a batch script, instead of three
* `sys.exit(1)` inform another programs that the code failed
* success message should be after resolving the 'c' dependency