### PR TITLE
improve and simplify windows installer

### DIFF
--- a/core/dependencies.py
+++ b/core/dependencies.py
@@ -85,7 +85,7 @@ def chocoInstall():
 def chocoInstaller(name):
     if not chocoInstall():
         return False
-    shell_exec_cmd = "powershell -Command \"Start-Process powershell -Verb RunAs -PassThru -Wait -ArgumentList \\\"/c choco install " + name + " -y; timeout /t 5; exit\\\"\""
+    shell_exec_cmd = "powershell -Command \"Start-Process powershell -Verb RunAs -PassThru -Wait -ArgumentList \\\"/c choco install " + name + "; timeout /t 5; exit\\\"\""
     print('# Installing dependency with Chocolatey - Command: \r\n')
     print(f'{shell_exec_cmd}\r\n')
     print('# Result:')

--- a/install.py
+++ b/install.py
@@ -16,26 +16,28 @@ try:
             os.remove(p_path)
         os.symlink(PHOTON_PATH, p_path)
         os.chmod(PHOTON_PATH, 0o777)
+        print(f'Photon Install Path: {p_path}')
     elif sys.platform in {'win32', 'cygwin', 'msys'} or os.name == "nt" or os.environ.get('OS', '') == 'Windows_NT':
         p_dir = os.path.expandvars('%ProgramFiles%\\Photon')
         if not os.path.exists(p_dir):
             os.mkdir(p_dir)
         with open(os.path.join(p_dir, 'photon.bat'), 'w') as w:
             w.write(f'@echo off\npython "{PHOTON_PATH}" %*')
-        os.system(f'setx /M PATH "%PATH%;{p_dir}"')
+        if p_dir in os.environ.get("PATH"):
+            print('Photon already on PATH, skipping')
+        else:
+            os.system(f'setx /M PATH "%PATH%;{p_dir}"')
+        print(f'Photon Install Path: {os.path.join(p_dir, "photon")}')
     else:
         print('Automatic installation in this system is not supported yet.')
-        input('Press enter to close')
         sys.exit(1)
 except PermissionError:
     print('The installation failed due to lack of permissions.',
           'Run the proper script for your operational system or try to execute this as super user/administrator',
           sep='\n')
-    input('Press enter to close')
     sys.exit(1)
 
 if not haveDependencies('c', sys.platform):
     resolveDependencies('c', sys.platform)
 
 print("Successfully installed! Now you can use the photon command!")
-input('Press enter to close and play with Photon!')

--- a/install.py
+++ b/install.py
@@ -16,9 +16,11 @@ try:
             os.remove(p_path)
         except FileNotFoundError:
             pass  # ensure the path does not exists
+        else:
+            print('Removing and creating new symlink')
         os.symlink(PHOTON_PATH, p_path)
         os.chmod(PHOTON_PATH, 0o777)
-        print(f'Photon Install Path: {p_path}')
+        print(f'Photon Command Path: {p_path}')
     elif sys.platform in {'win32', 'cygwin', 'msys'} or os.name == "nt" or os.environ.get('OS', '') == 'Windows_NT':
         p_dir = os.path.expandvars('%ProgramFiles%\\Photon')
         if not os.path.exists(p_dir):
@@ -29,7 +31,7 @@ try:
             print('Photon already on PATH, skipping')
         else:
             os.system(f'setx /M PATH "%PATH%;{p_dir}"')
-        print(f'Photon Install Path: {os.path.join(p_dir, "photon")}')
+        print(f'Photon Command Path: {os.path.join(p_dir, "photon")}')
     else:
         print('Automatic installation in this system is not supported yet.')
         sys.exit(1)

--- a/windowsInstaller.bat
+++ b/windowsInstaller.bat
@@ -1,26 +1,4 @@
 @ECHO OFF
-TITLE Windows Installer - Photon
-CLS
-ECHO.
-IF EXIST %SYSTEMROOT%\SYSTEM32\WDI\LOGFILES GOTO GT_ADMIN
-COLOR 0F
-ECHO Commands for running with normal privileges
-SET mydir=%~dp0
-POWERSHELL -COMMAND "Start-Process \"%mydir%windowsInstaller.bat\" -Verb RunAs"
-TIMEOUT /T 3 /NOBREAK
-EXIT
 
-:GT_ADMIN
-COLOR 1F
-ECHO Commands for running with admin privileges
-MSG /TIME 3 * Await Windows Installer of Photon! (Part 1)
-POWERSHELL -COMMAND "Start-Process powershell -Verb RunAs -PassThru -Wait -ArgumentList \"/c New-ItemProperty -Path HKLM:Software\Microsoft\Windows\CurrentVersion\policies\system -Name EnableLUA -PropertyType DWord -Value 0 -Force; Set-ItemProperty -Path HKLM:\Software\Microsoft\Windows\CurrentVersion\policies\system -Name EnableLUA -Value 0 -Force; timeout /t 3; exit\""
-MSG /TIME 3 * Await Windows Installer of Photon! (Part 2)
-POWERSHELL -COMMAND "Start-Process powershell -Verb RunAs -PassThru -Wait -ArgumentList \"/c Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); ; timeout /t 3; exit\""
-MSG /TIME 3 * Await Windows Installer of Photon! (Part 3)
-POWERSHELL -COMMAND "Start-Process powershell -Verb RunAs -PassThru -Wait -ArgumentList \"/c choco install python mingw git -y; timeout /t 3; exit\""
-MSG /TIME 3 * Await Windows Installer of Photon! (Part 4)
-POWERSHELL -COMMAND "Start-Process powershell -Verb RunAs -PassThru -Wait -ArgumentList \"/c pip install pyreadline; python '%~dp0/install.py'; timeout /t 3; exit\""
-MSG /TIME 3 * Photon successfully installed!
-TIMEOUT /T 3 /NOBREAK
-EXIT
+SET mydir=%~dp0
+powershell -command "Start-Process powershell -Verb RunAs -PassThru -ArgumentList \"-ExecutionPolicy RemoteSigned -NoProfile -File %mydir%\windowsInstaller.ps1\""

--- a/windowsInstaller.ps1
+++ b/windowsInstaller.ps1
@@ -1,0 +1,18 @@
+# $ErrorActionPreference = "Stop"
+
+$host.UI.RawUI.WindowTitle = "Windows Installer - Photon"
+
+New-ItemProperty -Path HKLM:Software\Microsoft\Windows\CurrentVersion\policies\system -Name EnableLUA -PropertyType DWord -Value 0 -Force
+Set-ItemProperty -Path HKLM:\Software\Microsoft\Windows\CurrentVersion\policies\system -Name EnableLUA -Value 0 -Force
+
+Set-ExecutionPolicy Bypass -Scope Process -Force
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+choco install python mingw git
+pip install pyreadline
+
+$scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+python "$scriptPath\install.py"
+
+Pause

--- a/windowsInstaller.ps1
+++ b/windowsInstaller.ps1
@@ -10,7 +10,23 @@ Set-ExecutionPolicy Bypass -Scope Process -Force
 iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 $env:Path = "$env:Path;$env:AllUsersProfile\chocolatey\bin"
 
-choco install python mingw git
+if ((Get-Command "python.exe" -ErrorAction SilentlyContinue) -eq $null) 
+{ 
+   $dependencies = " python"
+}
+if ((Get-Command "gcc.exe" -ErrorAction SilentlyContinue) -eq $null) 
+{ 
+   $dependencies = "$dependencies mingw"
+}
+if ((Get-Command "git.exe" -ErrorAction SilentlyContinue) -eq $null) 
+{ 
+   $dependencies = "$dependencies git"
+}
+
+if (Get-Variable 'dependencies' -ErrorAction 'Ignore') {
+  choco install $dependencies
+}
+
 pip install pyreadline
 
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition

--- a/windowsInstaller.ps1
+++ b/windowsInstaller.ps1
@@ -8,6 +8,7 @@ Set-ItemProperty -Path HKLM:\Software\Microsoft\Windows\CurrentVersion\policies\
 Set-ExecutionPolicy Bypass -Scope Process -Force
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
 iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+$env:Path = "$env:Path;$env:AllUsersProfile\chocolatey\bin"
 
 choco install python mingw git
 pip install pyreadline


### PR DESCRIPTION
* open only one powershell instance
* change `input` on `install.py` to `Pause` on `windowsInstaller.ps1`
* add prints about installation
* check if directory is already on PATH, before readding
* check if dependencies are already installed before using chocolatey
* fix unknown error with `os.path.exists` (linux)

TODO: maybe another name to the `.ps1` file, or another location

![Windows Installer](https://user-images.githubusercontent.com/66187211/117244654-ceab3000-ae0f-11eb-8d58-088db46bae4a.png)
