### PR TITLE
Fix various Windows bugs on installation

### DIFF
--- a/windowsInstaller.bat
+++ b/windowsInstaller.bat
@@ -1,6 +1,6 @@
 @echo off
 title Windows Installer - Photon
 set mydir=%~dp0
-powershell -command "Start-Process powershell -Verb RunAs -PassThru -ArgumentList \"-ExecutionPolicy RemoteSigned -NoProfile -File %mydir%\windowsInstaller.ps1\""
+powershell -command "Start-Process powershell -Verb RunAs -PassThru -ArgumentList '-ExecutionPolicy RemoteSigned -NoProfile -File \"%mydir%\windowsInstaller.ps1\"'"
 timeout /t 3
 exit

--- a/windowsInstaller.ps1
+++ b/windowsInstaller.ps1
@@ -20,27 +20,31 @@ while ((Get-Command "choco.exe" -ErrorAction SilentlyContinue) -eq $null)
 }
 
 $dependencies = ""
+$show_dependencies = ""
 
-if ((Get-Command "python.exe" -ErrorAction SilentlyContinue) -eq $null) 
+if (((Get-Command "python.exe" -ErrorAction SilentlyContinue) -eq $null) -or ((Get-Item (Get-Command "python.exe").Path).length -eq 0))
 {
-   $dependencies = "python "
+   $dependencies = "python;"
+   $show_dependencies = "python "
 }
 
-if ((Get-Command "gcc.exe" -ErrorAction SilentlyContinue) -eq $null) 
+if ((Get-Command "gcc.exe" -ErrorAction SilentlyContinue) -eq $null)
 {
-   $dependencies = "${dependencies}mingw "
+   $dependencies = "${dependencies}mingw;"
+   $show_dependencies = "${show_dependencies}mingw "
 }
 
-if ((Get-Command "git.exe" -ErrorAction SilentlyContinue) -eq $null) 
+if ((Get-Command "git.exe" -ErrorAction SilentlyContinue) -eq $null)
 {
-   $dependencies = "${dependencies}git "
+   $dependencies = "${dependencies}git;"
+   $show_dependencies = "${show_dependencies}git "
 }
 
-if ($dependencies -ne "") 
+if ($dependencies -ne "")
 {
-   echo "To use Photon, you need to install the following programs: ${dependencies}"
+   echo "To use Photon, you need to install the following programs: ${show_dependencies}"
    pause
-   choco install -y $dependencies
+   choco install -y "$dependencies"
 } 
 else 
 {

--- a/windowsInstaller.ps1
+++ b/windowsInstaller.ps1
@@ -53,10 +53,10 @@ else
 
 if ((Get-Command "python.exe" -ErrorAction SilentlyContinue) -ne $null) 
 {
-   python -m pip install pyreadline
+   cmd /c "refreshenv; python -m pip install pyreadline"
    $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
    echo "Installing Photon . . ."
-   python "${scriptPath}\install.py"
+   cmd /c "python  '${scriptPath}\install.py'"
 }
 else
 {


### PR DESCRIPTION
Would be caused by:
* spaces on paths
* chocolatey specific argument format
* python.exe is a microsoft ad, not real python
* python installed by chocolatey is not on a default installation path