### PR TITLE
Instalador

### DIFF
--- a/linuxInstaller.sh
+++ b/linuxInstaller.sh
@@ -5,17 +5,24 @@ normal='\033[0m'
 
 printf "${green}Linux Installer - Photon${normal}\n"
 
+
+SUDO=''
+if (( $EUID != 0 )); then
+    SUDO='sudo'
+fi
+
+
 if [ -f '/etc/debian_version' ]; then
-    sudo apt-get update && sudo apt-get install python3 build-essential git
+    $SUDO apt update && $SUDO apt install python3 build-essential git
 elif [ -f '/etc/arch-release' ]; then
-    sudo pacman -Syy python gcc git glibc
+    $SUDO pacman -Syy python gcc git glibc
 elif [ -f '/etc/gentoo-release' ]; then
-    sudo emerge --sync && sudo emerge dev-lang/python sys-devel/gcc dev-vcs/git
+    $SUDO emerge --sync && $SUDO emerge dev-lang/python sys-devel/gcc dev-vcs/git
 elif [ -f '/etc/SuSE-release' ]; then
-    sudo zypper refresh && sudo zypper install python3 gcc git
+    $SUDO zypper refresh && $SUDO zypper install python3 gcc git
 elif [ -f '/etc/redhat-release' ]; then
-    (sudo dnf check-update && sudo dnf install python3 gcc git) ||
-    (sudo yum check-update && sudo yum install python3 gcc git)
+    ($SUDO dnf check-update && $SUDO dnf install python3 gcc git) ||
+    ($SUDO yum check-update && $SUDO yum install python3 gcc git)
 else
     printf "${red}Automatic installation in this system is not supported yet.\n${normal}"
     exit 1
@@ -25,9 +32,9 @@ SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
 if command -v python3; then
-    sudo python3 "$SCRIPTPATH/install.py"
+    $SUDO python3 "$SCRIPTPATH/install.py"
 elif command -v python; then
-    sudo python "$SCRIPTPATH/install.py"
+    $SUDO python "$SCRIPTPATH/install.py"
 else
     printf "${red}Was not possible to install Python >= 3.6, please do it manually\n${normal}"
     exit 1

--- a/linuxInstaller.sh
+++ b/linuxInstaller.sh
@@ -7,7 +7,7 @@ printf "${green}Linux Installer - Photon${normal}\n"
 
 
 SUDO=''
-if (( $EUID != 0 )); then
+if [ $(id -u) -ne 0 ] ; then
     SUDO='sudo'
 fi
 


### PR DESCRIPTION
Fiz testes com o Photon num container docker e apresentava erro, porque quando entrava no container já era com super usuáiro, então o comando sudo não funciona abaixo a mensagem de erro:
---
```
root@07ab90d8c47e:/home/teste/Photon# sh linuxInstaller.sh
Linux Installer - Photon
linuxInstaller.sh: 9: sudo: not found
Was not possible to install Python >= 3.6, please do it manually
```

Modifiquei o arquivo de instalação `linuxInstaller.sh` adicionando essa piquena linha de código:

```
SUDO=''
if [ $(id -u) -ne 0 ] ; then
    SUDO='sudo'
fi
```

A variável `$SUDO` antes de cada comando, só para verificar se o usuário deu o comando `sudo su` antes de iniciar a instalação, depois dessa atualização fiz novos testes num container docker novo e funcionou corretamente, testei na minha máquina como usuário normal e dando `sudo sh linuxInstaller.sh` e `sh linuxInstaller.sh` ele pediu a senha corretamente, no final deu tudo certo, segue a mensagem de confirmação:
---
```
root@6bd3efccd568:/home/teste_2/Photon# photon
Photon - 0.0.2 - pyEngine
```
